### PR TITLE
Do not throw Exception on 8-byte unsigned values

### DIFF
--- a/src/main/java/com/google/iot/cbor/CborInteger.java
+++ b/src/main/java/com/google/iot/cbor/CborInteger.java
@@ -15,6 +15,8 @@
  */
 package com.google.iot.cbor;
 
+import javax.annotation.Nullable;
+
 /** CBOR integer object interface. */
 public abstract class CborInteger extends CborObject implements CborNumber {
     // Prohibit users from subclassing for now.
@@ -25,7 +27,11 @@ public abstract class CborInteger extends CborObject implements CborNumber {
     }
 
     public static CborInteger create(long value, int tag) {
-        return new CborIntegerImpl(value, tag);
+        return create(value, tag, null);
+    }
+
+    public static CborInteger create(long value, int tag, @Nullable Integer majorType) {
+        return new CborIntegerImpl(value, tag, majorType);
     }
 
     static int calcAdditionalInformation(long val) {
@@ -58,7 +64,7 @@ public abstract class CborInteger extends CborObject implements CborNumber {
     }
 
     @Override
-    public final int getMajorType() {
+    public int getMajorType() {
         return (longValue() < 0) ? CborMajorType.NEG_INTEGER : CborMajorType.POS_INTEGER;
     }
 
@@ -190,7 +196,13 @@ public abstract class CborInteger extends CborObject implements CborNumber {
 
     @Override
     public String toString() {
-        String ret = Long.toString(longValue());
+        String ret;
+        if(getMajorType() == CborMajorType.POS_INTEGER) {
+            // handle the case of a 64bit unsigned positive integer value
+            ret = Long.toUnsignedString(longValue());
+        } else {
+            ret = Long.toString(longValue());
+        }
 
         int tag = getTag();
 

--- a/src/main/java/com/google/iot/cbor/CborIntegerImpl.java
+++ b/src/main/java/com/google/iot/cbor/CborIntegerImpl.java
@@ -16,22 +16,32 @@
 
 package com.google.iot.cbor;
 
+import javax.annotation.Nullable;
+
 final class CborIntegerImpl extends CborInteger {
     private final long mValue;
     private final int mTag;
+    private final Integer mMajorType;
 
     @Override
     public int getTag() {
         return mTag;
     }
 
-    CborIntegerImpl(long value, int tag) {
+    CborIntegerImpl(long value, int tag, @Nullable Integer majorType) {
         if (!CborTag.isValid(tag)) {
             throw new IllegalArgumentException("Invalid tag value " + tag);
         }
 
         mTag = tag;
         mValue = value;
+        mMajorType = majorType;
+    }
+
+    @Override
+    public int getMajorType() {
+        if(mMajorType != null) return mMajorType;
+        return super.getMajorType();
     }
 
     @Override

--- a/src/main/java/com/google/iot/cbor/CborReaderImpl.java
+++ b/src/main/java/com/google/iot/cbor/CborReaderImpl.java
@@ -101,8 +101,8 @@ class CborReaderImpl implements CborReader {
                 // We perform an overflow check here by checking for negative values.
                 // We don't currently support the full use of 64 bit unsigned integers,
                 // so any number larger than Long.MAX_VALUE will ultimately be wrapped
-                // around to be negative. This check identifies such cases and errors
-                // out, EXCEPT when we are a double-precision float.
+                // around to be negative. This check identifies such cases and warns
+                // the user, EXCEPT when we are a double-precision float.
                 // <https://github.com/google/cbortree/issues/1>
                 if (additionalData < 0 && majorType != CborMajorType.OTHER) {
                     final String explanation =
@@ -117,8 +117,8 @@ class CborReaderImpl implements CborReader {
                         additionalData = CborTag.UNTAGGED;
 
                     } else {
-                        LOGGER.warning(explanation + ", stopping");
-                        throw new CborParseException(explanation);
+                        LOGGER.warning(explanation +
+                                ", long wrapped to negative, use Long.toUnsignedString() for display");
                     }
                 }
 
@@ -145,12 +145,8 @@ class CborReaderImpl implements CborReader {
                     return readDataItem();
 
                 case CborMajorType.POS_INTEGER:
-                    if (additionalData < 0) {
-                        throw new CborParseException();
-                    } else {
-                        if (mRemainingObjects != UNSPECIFIED) mRemainingObjects--;
-                        return CborInteger.create(additionalData, tag);
-                    }
+                    if (mRemainingObjects != UNSPECIFIED) mRemainingObjects--;
+                    return CborInteger.create(additionalData, tag, CborMajorType.POS_INTEGER);
 
                 case CborMajorType.NEG_INTEGER:
                     if (additionalData < 0) {

--- a/src/test/java/com/google/iot/cbor/CborIntegerTest.java
+++ b/src/test/java/com/google/iot/cbor/CborIntegerTest.java
@@ -16,10 +16,11 @@
 
 package com.google.iot.cbor;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.logging.Logger;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({"ConstantConditions", "unused"})
 public class CborIntegerTest extends CborTestBase {
@@ -225,5 +226,14 @@ public class CborIntegerTest extends CborTestBase {
         assertThrows(
                 CborConversionException.class,
                 () -> CborObject.createFromJavaObject(obj.toJavaObject(String.class)));
+    }
+
+    @Test
+    void testLongOverflow() {
+        byte[] array = decode("1b8ac7230489e80000");
+
+        String output = "10000000000000000000";
+
+        CborObject obj = assertParseToString(output, array);
     }
 }


### PR DESCRIPTION
Java doesn't allow 64 bit unsigned long values, but they do support converting them to strings properly. 

Don't error out with an exception and instead allow the implementer the chance to handle the conversion into a string or eventually to a BigInteger themselves.