### PR TITLE
CborMap: don't throw on `toJsonString` when `null`

### DIFF
--- a/src/main/java/com/google/iot/cbor/CborMap.java
+++ b/src/main/java/com/google/iot/cbor/CborMap.java
@@ -417,7 +417,12 @@ public abstract class CborMap extends CborObject {
                 sb.append(JSONObject.quote(entry.getKey().toJsonString()));
             }
             sb.append(":");
-            sb.append(entry.getValue().toJsonString());
+            CborObject e = entry.getValue();
+            if (e != null) {
+                sb.append(e.toJsonString());
+            } else {
+                sb.append("null");
+            }
         }
         sb.append("}");
         return sb.toString();

--- a/src/test/java/com/google/iot/cbor/CborMapTest.java
+++ b/src/test/java/com/google/iot/cbor/CborMapTest.java
@@ -194,4 +194,14 @@ public class CborMapTest extends CborTestBase {
                 CborConversionException.class,
                 () -> CborObject.createFromJavaObject(obj.toJavaObject(String[].class)));
     }
+
+    @Test
+    void testJsonNull() {
+        String output = "{\"Fun\":null}";
+
+        CborMap obj = CborMap.create();
+        //noinspection DataFlowIssue
+        obj.put("Fun", null);
+        assertEquals(output, obj.toJsonString());
+    }
 }


### PR DESCRIPTION
The `CborMap.apply(put("Fun", null)).toJsonString()` will throw an NPE exception, when the expectected behavior should be formatting a `"Fun":null` string.

Add test to verify correct behavior.